### PR TITLE
Add optional argument "missing" to XGDMatrix

### DIFF
--- a/src/xgboost.cpp
+++ b/src/xgboost.cpp
@@ -282,9 +282,9 @@ PHP_METHOD(DMatrix, __construct)
 	zval* input_arr;
 	bst_ulong nrow;
 	bst_ulong ncol;
-	float missing = 0;
+	double missing = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "al", &input_arr, &ncol) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "al|d", &input_arr, &ncol, &missing) == FAILURE) {
 		RETURN_NULL();
 	}
 
@@ -306,7 +306,7 @@ PHP_METHOD(DMatrix, __construct)
 
  			XG_FOREACH_VAL(Z_ARRVAL_P(entry), row_entry) {
 
-				register float el = missing;
+				register float el = (float)missing;
 				XG_EXTRACT_DVAL_P(row_entry, el);
 				row_buf[col] = el;
 				col++;
@@ -320,7 +320,7 @@ PHP_METHOD(DMatrix, __construct)
 	} XG_FOREACH_END();
 
 	dmatrix_object * obj = XG_GET_THIS(dmatrix_object);
-	if (!check_xgboost_call(XGDMatrixCreateFromMat(data, nrow, ncol, missing, &(obj->handle)))) {
+	if (!check_xgboost_call(XGDMatrixCreateFromMat(data, nrow, ncol, (float)missing, &(obj->handle)))) {
 		RETURN_NULL();
 	}
 


### PR DESCRIPTION
"Missing" is a useful argument in XGDMatrix constructor, but in the current implementation, it was always set to 0.0
In this PR I added a third optional argument to XGDMatrix constructor.
New constructor signature will look like:
`$matrix = new XGDMatrix(array $data, int $ncols [, float missing = 0]);`